### PR TITLE
TNG-785 add tests for paragraph

### DIFF
--- a/src/components/Paragraph/__tests__/Paragraph.spec.ts
+++ b/src/components/Paragraph/__tests__/Paragraph.spec.ts
@@ -1,0 +1,27 @@
+import { getByText, render } from "@testing-library/vue";
+import Paragraph from "./../";
+
+describe("components/Paragraph", () => {
+  it("renders passed content as paragraph content", () => {
+    const content = "This is my test for paragraph";
+    const { getByText } = render(Paragraph, {
+      slots: { default: content },
+    });
+    const paragraphText = getByText(content);
+    expect(paragraphText).toBeTruthy();
+  });
+  it("check the paragraph properties", () => {
+    const content = "This is my test for paragraph";
+    const size = "lg";
+    const weight = "bold";
+    const { container } = render(Paragraph, {
+      slots: { default: content },
+      props: {
+        size,
+        weight,
+      },
+    });
+    const propsTest = container.querySelector(`.text-${size}.font-${weight}`);
+    expect(propsTest).toBeTruthy();
+  });
+});


### PR DESCRIPTION
I wrote tests for the paragraph component. 
The first test checks, if the content was rendered properly. 
The second one checks, if the paragraph text has the right properties ( size + weight ).