### PR TITLE
docs: added responsive Buttons to view the components

### DIFF
--- a/src/components/internal/Documentation/Code/index.tsx
+++ b/src/components/internal/Documentation/Code/index.tsx
@@ -7,11 +7,13 @@ import "prismjs/themes/prism-okaidia.css";
 import "./style.css";
 import Toggle from "@/components/internal/Toggle";
 import { CodeProps } from "@/types/components";
+import ComponentIFrame from "@/components/internal/Documentation/ComponentIFrame";
 
 @Component
 class Code extends BaseComponent<CodeProps> {
   @Prop() code!: CodeProps["code"];
   @Prop() language: CodeProps["language"];
+  @Prop() filename: CodeProps["filename"];
 
   darkMode = false;
   copied = false;
@@ -42,7 +44,14 @@ class Code extends BaseComponent<CodeProps> {
       <div class={`Code ${this.darkMode ? "dark" : ""}`}>
         {this.$slots.default ? (
           <div class="Code--Example">
-            {this.$slots.default}
+            {this.filename && (
+              <ComponentIFrame
+                filename={this.filename}
+                dark={this.darkMode}
+                class="mx-auto"
+              />
+            )}
+
             <div class="Code--BackgroundToggle">
               <Toggle
                 active={this.darkMode}

--- a/src/components/internal/Documentation/ComponentIFrame/index.tsx
+++ b/src/components/internal/Documentation/ComponentIFrame/index.tsx
@@ -1,0 +1,88 @@
+import "vue-tsx-support/enable-check";
+import { Component, Prop } from "vue-property-decorator";
+import { BaseComponent } from "fsxa-ui";
+import ResponsiveButton from "@/components/internal/Documentation/ResponsiveButton";
+
+interface ComponentIFrameProps {
+  filename: string;
+  dark?: boolean;
+}
+
+type possibleWidths =
+  | "max-w-screen-xs"
+  | "max-w-screen-sm"
+  | "max-w-screen-md"
+  | "max-w-screen-lg"
+  | "max-w-screen-xl"
+  | "";
+
+@Component({
+  name: "ComponentIFrame",
+})
+class ComponentIFrame extends BaseComponent<ComponentIFrameProps> {
+  @Prop({ required: true }) filename!: ComponentIFrameProps["filename"];
+  @Prop({ default: false }) dark!: ComponentIFrameProps["dark"];
+
+  parsedFilename = this.filename.replace(".tsx", "").replace(".", "-");
+
+  resizeFrame() {
+    const iframe = this.$refs.iframe as HTMLIFrameElement;
+    if (iframe.contentWindow) {
+      iframe.style.height =
+        iframe.contentWindow.document.documentElement.scrollHeight + "px";
+    } else {
+      iframe.style.height = "100px";
+    }
+  }
+
+  pressedButtonIndex = 4;
+
+  iframeWidth: possibleWidths = "";
+
+  buttonSettings: { width: possibleWidths; iconClass: string }[] = [
+    { width: "max-w-screen-xs", iconClass: "fas fa-mobile-alt" },
+    { width: "max-w-screen-sm", iconClass: "fas fa-tablet-alt" },
+    { width: "max-w-screen-md", iconClass: "fas fa-tablet-alt fa-rotate-90" },
+    { width: "max-w-screen-lg", iconClass: "fas fa-laptop" },
+    { width: "", iconClass: "fas fa-tv" },
+  ];
+
+  render() {
+    return (
+      <div class="bg-gray-400">
+        <div
+          class={`flex space-x-4 justify-center ${
+            this.dark ? "bg-black" : "bg-white"
+          } text-xl`}
+        >
+          {this.buttonSettings.map((button, index) => {
+            return (
+              <ResponsiveButton
+                dark={this.dark}
+                pressed={this.pressedButtonIndex === index}
+                handleOnClick={() => {
+                  this.pressedButtonIndex = index;
+                  this.iframeWidth = button.width;
+                }}
+              >
+                <i class={button.iconClass} />
+              </ResponsiveButton>
+            );
+          })}
+        </div>
+        <iframe
+          src={`/#/raw-component/${this.parsedFilename}`}
+          scrolling="yes"
+          width="100%"
+          class={`mx-auto ${this.dark ? "bg-black" : "bg-white"} ${
+            this.iframeWidth
+          }`}
+          ref="iframe"
+          onLoad={this.resizeFrame}
+        />
+      </div>
+    );
+  }
+}
+
+export default ComponentIFrame;

--- a/src/components/internal/Documentation/Example/index.tsx
+++ b/src/components/internal/Documentation/Example/index.tsx
@@ -5,16 +5,18 @@ import Code from "@/components/internal/Documentation/Code";
 export interface ExampleProps {
   code: string;
   renderCallback: () => JSX.Element;
+  filename: string;
 }
 @Component
 class Example extends BaseComponent<ExampleProps> {
   @Prop({ required: true }) code!: ExampleProps["code"];
+  @Prop({ required: true }) filename!: ExampleProps["filename"];
   @Prop({ required: true }) renderCallback!: ExampleProps["renderCallback"];
 
   render() {
     const Component = this.renderCallback;
     return (
-      <Code code={this.code} language="typescript">
+      <Code filename={this.filename} code={this.code} language="typescript">
         <Component />
       </Code>
     );

--- a/src/components/internal/Documentation/ResponsiveButton/index.tsx
+++ b/src/components/internal/Documentation/ResponsiveButton/index.tsx
@@ -1,0 +1,34 @@
+import "vue-tsx-support/enable-check";
+import { Component, Prop } from "vue-property-decorator";
+import { BaseComponent } from "fsxa-ui";
+
+interface ResponsiveButtonProps {
+  handleOnClick: () => void;
+  pressed?: boolean;
+  dark?: boolean;
+}
+
+@Component({
+  name: "ResponsiveButton",
+})
+class ResponsiveButton extends BaseComponent<ResponsiveButtonProps> {
+  @Prop({ required: true })
+  handleOnClick!: ResponsiveButtonProps["handleOnClick"];
+  @Prop({ default: false }) pressed!: ResponsiveButtonProps["pressed"];
+  @Prop({ default: false }) dark!: ResponsiveButtonProps["dark"];
+
+  render() {
+    return (
+      <div
+        class={`px-4 py-2 shadow-2xl rounded cursor-pointer border  ${
+          this.pressed ? "text-espirit" : this.dark ? "text-white" : ""
+        }`}
+        onClick={this.handleOnClick}
+      >
+        {this.$slots.default}
+      </div>
+    );
+  }
+}
+
+export default ResponsiveButton;

--- a/src/documentation/examples/Sections/AccordionSection.tsx
+++ b/src/documentation/examples/Sections/AccordionSection.tsx
@@ -8,7 +8,7 @@ export default class App extends Vue {
   render() {
     return (
       <div>
-        <div class="m-2 w-1/3">
+        <div class="m-2 max-w-lg">
           <Sections.AccordionSection
             dark={false}
             title={"This title is optional"}
@@ -29,7 +29,7 @@ export default class App extends Vue {
             ]}
           />
         </div>
-        <div class="m-2 w-1/2">
+        <div class="m-2 max-w-xl">
           <Sections.AccordionSection
             dark={true}
             items={[

--- a/src/documentation/index.tsx
+++ b/src/documentation/index.tsx
@@ -131,10 +131,10 @@ const routes = [
   name: "Documentation",
 })
 class Documentation extends BaseComponent {
-  showSidebar = false;
-
   render() {
-    return (
+    return this.$route.meta.singleView ? (
+      <router-view />
+    ) : (
       <div class="w-full min-h-full flex">
         <div class="md:w-1/3 lg:w-1/4 md:max-w-xs border-r border-gray-300 hidden md:block p-5">
           <div class="p-5 flex items-center">

--- a/src/documentation/router.ts
+++ b/src/documentation/router.ts
@@ -14,6 +14,23 @@ const extractRoute = (route: string) => {
 
 // load page structure
 const data = require.context("./docs", true, /[a-zA-Z0-9]+\.mdx$/);
+const examples = require.context("./examples", true, /[a-zA-Z0-9]+\.tsx$/);
+
+const exampleRoutes = examples.keys().map(path => {
+  const parsedPath = path
+    .replace(".tsx", "")
+    .replace("./", "")
+    .replace(".", "-");
+  return {
+    path: "/raw-component/" + parsedPath,
+    label: "RawComponent",
+    component: examples(path).default,
+    meta: {
+      singleView: true,
+    },
+  };
+});
+
 export const routes: any = data
   .keys()
   .map(path => {
@@ -24,7 +41,8 @@ export const routes: any = data
       ...route,
     };
   })
-  .filter(route => route);
+  .filter(route => route)
+  .concat(exampleRoutes);
 
 const router = new VueRouter({
   routes,

--- a/src/documentation/utils/ExampleLoader.tsx
+++ b/src/documentation/utils/ExampleLoader.tsx
@@ -21,7 +21,13 @@ class ExampleLoader extends BaseComponent<ExampleLoaderProps> {
       throw new Error(
         `Could not find file in @/documentation/examples/examples/${this.example}`,
       );
-    return <Example renderCallback={content.default} code={code.default} />;
+    return (
+      <Example
+        filename={this.example}
+        renderCallback={content.default}
+        code={code.default}
+      />
+    );
   }
 }
 export default ExampleLoader;

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -21,6 +21,7 @@ export interface CodeProps {
   code: string;
   language?: string;
   exampleContent?: JSX.Element;
+  filename?: string;
 }
 export class Code extends Component<CodeProps> {}
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,12 +16,9 @@ module.exports = {
       transparent: "transparent",
       current: "currentColor",
       espirit: "#810444",
-
       black: "#000",
       white: "#fff",
-
       highlight: "var(--fsxa-text-highlight-color, #D5DD02)",
-
       gray: {
         100: "#f7fafc",
         200: "#edf2f7",
@@ -349,6 +346,7 @@ module.exports = {
       "6xl": "72rem",
       full: "100%",
       ...breakpoints(theme("screens")),
+      "screen-xs": "400px",
     }),
     minHeight: {
       "0": "0",


### PR DESCRIPTION
Here the possibility was implemented to view the components in their responsive representation. For
this purpose the components are displayed one by one on a page which can be found under
"/raw-component/{:component-name}". This page is integrated on the detail page of the component via
iFrame. To change the view, buttons have been added which influence the width of the displayed
iFrame.