### PR TITLE
fix(newsdetail component): changed some props and layout issues

### DIFF
--- a/src/components/NewsDetail/index.tsx
+++ b/src/components/NewsDetail/index.tsx
@@ -1,21 +1,21 @@
-import { NewsDetailProps } from "@/types/fsxa-ui";
-import { Component, Prop } from "vue-property-decorator";
-import "./style.css";
 import {
   BaseComponent,
-  Headline,
-  Paragraph,
-  Image,
   Button,
   Container,
+  Headline,
+  Image,
   Layout,
   LayoutItem,
+  Paragraph,
 } from "@/components";
+import { NewsDetailProps, NewsDetailSlots } from "@/types/fsxa-ui";
+import { Component, Prop } from "vue-property-decorator";
+import "./style.css";
 
 @Component({
   name: "NewsDetail",
 })
-class NewsDetail extends BaseComponent<NewsDetailProps> {
+class NewsDetail extends BaseComponent<NewsDetailProps, {}, NewsDetailSlots> {
   @Prop({ required: true }) headline!: NewsDetailProps["headline"];
   @Prop({ required: false }) teaser!: NewsDetailProps["teaser"];
   @Prop({ required: true }) image!: NewsDetailProps["image"];
@@ -28,7 +28,7 @@ class NewsDetail extends BaseComponent<NewsDetailProps> {
   handleTagClick!: NewsDetailProps["handleTagClick"];
   @Prop({ required: false })
   returnText!: NewsDetailProps["returnText"];
-  @Prop({ required: false }) socialText!: NewsDetailProps["socialText"];
+  @Prop({ required: false }) social!: NewsDetailProps["social"];
 
   render() {
     return (
@@ -37,10 +37,10 @@ class NewsDetail extends BaseComponent<NewsDetailProps> {
           {this.headline}
         </Headline>
         {this.teaser && <Paragraph size="md">{this.teaser}</Paragraph>}
-        <Image class="ui-my-2" src={this.image.src} />
+        <Image class="ui-my-2" props={this.image} />
         {(this.date || this.author) && (
           <div class="ui-text-sm">
-            {this.date && new Date(this.date).toLocaleDateString()}
+            {this.date && <span>{this.date}</span>}
             {this.author && (
               <span class="ui-text-gray-600"> | {this.author}</span>
             )}
@@ -58,7 +58,7 @@ class NewsDetail extends BaseComponent<NewsDetailProps> {
                 <Headline
                   as="h5"
                   size="md"
-                  class="ui-mx-auto lg:ui-mx-0 ui-text-center lg:ui-text-left"
+                  class="lg:ui-mx-0 lg:ui-ml-4 ui-text-left"
                 >
                   TAGS
                 </Headline>
@@ -82,45 +82,56 @@ class NewsDetail extends BaseComponent<NewsDetailProps> {
             {this.returnText && (
               <Button
                 variant="tag"
-                class="return-newsroom-btn"
+                class="ui-font-light ui-mt-2 ui-text-base ui-tracking-widest"
                 handleClick={this.handleReturnClick}
               >
                 {this.returnText}
               </Button>
             )}
           </LayoutItem>
-          <LayoutItem
-            width="full"
-            lg={{ width: "1/2" }}
-            class="ui-mx-auto lg:ui-mx-0"
-          >
-            {this.socialText && (
-              <Headline
-                as="h5"
-                size="md"
-                class="ui-mx-auto lg:ui-mx-px ui-text-center lg:ui-text-left"
-              >
-                {this.socialText}
-              </Headline>
-            )}
-            <div class="ui-mx-auto lg:ui-mx-px">
-              <Button variant="tag" class="ui-mr-2 ui-border ui-border-black">
-                <i class="fab fa-facebook-f" />
-              </Button>
-              <Button variant="tag" class="ui-mx-2 ui-border ui-border-black">
-                <i class="fab fa-twitter" />
-              </Button>
-              <Button variant="tag" class="ui-mx-2 ui-border ui-border-black">
-                <span class="fa fa-rss" />
-              </Button>
-              <Button variant="tag" class="ui-mx-2 ui-border ui-border-black">
-                <span class="fab fa-youtube" />
-              </Button>
-              <Button variant="tag" class="ui-ml-2 ui-border ui-border-black">
-                <i class="fab fa-instagram" />
-              </Button>
-            </div>
-          </LayoutItem>
+          {this.$scopedSlots.social && this.social ? (
+            <LayoutItem
+              width="full"
+              lg={{ width: "1/2" }}
+              class="ui-mx-auto lg:ui-mx-0"
+            >
+              {this.$scopedSlots.social(this.social)}
+            </LayoutItem>
+          ) : (
+            <LayoutItem
+              width="full"
+              lg={{ width: "1/2" }}
+              class="ui-mx-auto lg:ui-mx-0 ui-flex"
+            >
+              {this.social?.title && (
+                <Headline
+                  as="h5"
+                  size="md"
+                  class="ui-mx-auto lg:ui-mx-px ui-text-center md:ui-text-right"
+                >
+                  {this.social.title}
+                </Headline>
+              )}
+              <div class="ui-mx-auto lg:ui-mx-px ui-flex ui-space-y-2 md:ui-space-y-0 ui-flex-col md:ui-flex-row ui-justify-end">
+                {this.social?.items && this.social?.items?.length > 0
+                  ? this.social.items.map(item => (
+                      <div class="ui-mx-auto md:ui-mx-0">
+                        <Button
+                          variant="tag"
+                          class="ui-mr-2 ui-border ui-border-black"
+                          handleClick={() => {
+                            if (this.social?.handleSocialClick)
+                              this.social.handleSocialClick(item);
+                          }}
+                        >
+                          {item.title ? item.title : null}
+                        </Button>
+                      </div>
+                    ))
+                  : null}
+              </div>
+            </LayoutItem>
+          )}
         </Layout>
       </Container>
     );

--- a/src/components/NewsDetail/index.tsx
+++ b/src/components/NewsDetail/index.tsx
@@ -10,8 +10,6 @@ import {
 } from "@/components";
 import { NewsDetailProps, NewsDetailSlots } from "@/types/fsxa-ui";
 import { Component, Prop } from "vue-property-decorator";
-import "./style.css";
-
 @Component({
   name: "NewsDetail",
 })

--- a/src/components/NewsDetail/style.css
+++ b/src/components/NewsDetail/style.css
@@ -1,5 +1,0 @@
-.NewsDetail {
-  .return-newsroom-btn {
-    @apply ui-font-light ui-mt-2 ui-text-base ui-tracking-widest;
-  }
-}

--- a/src/documentation/docs/components/NewsDetail.mdx
+++ b/src/documentation/docs/components/NewsDetail.mdx
@@ -2,7 +2,9 @@ import Code from "@/components/internal/Documentation/Code";
 import ExampleLoader from "@/documentation/utils/ExampleLoader";
 import Meta from "@/components/internal/Documentation/Meta";
 import PropsTable from "@/components/internal/Documentation/PropsTable";
+import SlotsTable from "@/components/internal/Documentation/SlotsTable";
 import PropsTableRow from "@/components/internal/Documentation/PropsTable/components/PropsTableRow";
+import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/components/SlotsTableRow";
 
 <Meta
   title="NewsDetail"
@@ -13,47 +15,92 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
 
 <PropsTable>
   <PropsTableRow value="headline" type="String" required>
-    Specify which headline should be displayed.
+    Headline at the top of the page.
   </PropsTableRow>
   <PropsTableRow value="image" type="Object" required>
-    Specify which image should be displayed.
-    Required attributes are:
+    Image under the headline.
+    Possible attributes are:
     <ul>
-    <li><span class="code">src</span> Source of the image</li>
+    <li><span class="code">src</span>Required - string -  The src of the image.
+    
+    Note: If you are passing additional resolutions, this image src will be used as fallback
+    </li>
+    <li><span class="code">resolutions</span>Record&lt;String,{'{ url: string; width: number; height: number; }'} &gt;  
+   All available resolutions of your image that will be combined into a srcset statement</li>
+    <li><span class="code">sizes</span>string - Specfiy which size should be used with which viewport</li>
+    <li><span class="code">lazy</span>boolean - Specify if the image should be loaded only if it is visible in the viewport</li>
+    <li><span class="code">border</span>boolean - Specify if the shift / border should be applied</li>
+    <li><span class="code">zoom</span>boolean - Specify if the zoom-effect should be applied</li>
+    <li><span class="code">opacity</span>string - Specify if a black overlay with specified opacity should be applied on top. Possible values are "0" | "25" | "40" | "50" | "75" | "80"</li>
     </ul>
   </PropsTableRow>
-  <PropsTableRow value="tags" type="Array">
-      Specify which tags should be displayed. Required attributes are:
-      <ul>
-        <li><span class="code">label</span> Label of the tag</li>
-      </ul>
-
-  </PropsTableRow>
   <PropsTableRow value="teaser" type="String">
-    Specify which teaser should be displayed above the picture.
+    Text between headline and picture.
   </PropsTableRow>
   <PropsTableRow value="date" type="String">
-      Specify which date should be displayed.
+      Date when the article was written
+  </PropsTableRow>
+  <PropsTableRow value="tags" type="Array">
+      Tags under the article. Possible attributes are:
+      <ul>
+        <li><span class="code">label</span>string - Required - Label of the tag</li>
+        <li><span class="code">id</span>number | string -  Id of the tag</li>
+      </ul>
   </PropsTableRow>
   <PropsTableRow value="author" type="String">
-      Specify which author should be displayed.
+    Author of the article
   </PropsTableRow>
   <PropsTableRow value="handleTagClick" type="Function">
       You can pass in an optional callback that will be triggered, when a tag
       is clicked.
     </PropsTableRow>
+  <PropsTableRow value="returnText" type="String">
+    The text that will be displayed on the return button under the article.
+  </PropsTableRow>
   <PropsTableRow value="handleReturnClick" type="Function">
         You can pass in an optional callback that will be triggered, when the return button
             is clicked.
   </PropsTableRow>
-  <PropsTableRow value="socialText" type="String">
-    The text that will be displayed above the social media icons in the footer.
-  </PropsTableRow>
-  <PropsTableRow value="returnText" type="String">
-    The text that will be displayed on the return button in the footer.
+  <PropsTableRow value="social" type="Object">
+    Information about sociallinks. Possible attributes are:
+    <ul>
+          <li><span class="code">title</span>string - Title of the social area</li>
+          <li><span class="code">items</span>Object - social media items. Possible attributes are
+            <ul>
+              <li><span class="code">title</span>string - Title of the social element</li>
+              <li><span class="code">id</span>number | string - id of the social element</li>
+              <li><span class="code">options</span>Object - additional information of the social element</li>
+            </ul>            
+          </li>
+          <li><span class="code">handleItemClick</span>Function - Title of the social area</li>
+    </ul>
   </PropsTableRow>
 </PropsTable>
+
+## Slots
+
+<SlotsTable>
+  <SlotsTableRow value="social" prop="SocialArea">
+    Specify your custom HTML for the social area. These attributes you get as value:
+    <ul>
+          <li><span class="code">title</span>string - Title of the social area</li>
+          <li><span class="code">items</span>Object - social media items. Possible attributes are
+            <ul>
+              <li><span class="code">title</span>string - Title of the social element</li>
+              <li><span class="code">id</span>number | string - id of the social element</li>
+              <li><span class="code">options</span>Object - additional information of the social element</li>
+            </ul>            
+          </li>
+          <li><span class="code">handleItemClick</span>Function - Title of the social area</li>
+    </ul>
+  </SlotsTableRow>
+</SlotsTable>
+
 
 ## Example
 
 <ExampleLoader example="NewsDetail.tsx" />
+
+## Example with slots
+
+<ExampleLoader example="NewsDetail.slots.tsx" />

--- a/src/documentation/docs/components/NewsDetail.mdx
+++ b/src/documentation/docs/components/NewsDetail.mdx
@@ -21,13 +21,13 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
     Image under the headline.
     Possible attributes are:
     <ul>
-    <li><span class="code">src</span>Required - string -  The src of the image.
+    <li><span class="code">src</span>Required - string -  The source of the image.
     
-    Note: If you are passing additional resolutions, this image src will be used as fallback
+    Note: If you are passing additional resolutions, this image source will be used as fallback
     </li>
     <li><span class="code">resolutions</span>Record&lt;String,{'{ url: string; width: number; height: number; }'} &gt;  
-   All available resolutions of your image that will be combined into a srcset statement</li>
-    <li><span class="code">sizes</span>string - Specfiy which size should be used with which viewport</li>
+   All available resolutions of your image that will be combined into a sourceset statement</li>
+    <li><span class="code">sizes</span>string - Specify which size should be used with which viewport</li>
     <li><span class="code">lazy</span>boolean - Specify if the image should be loaded only if it is visible in the viewport</li>
     <li><span class="code">border</span>boolean - Specify if the shift / border should be applied</li>
     <li><span class="code">zoom</span>boolean - Specify if the zoom-effect should be applied</li>

--- a/src/documentation/examples/NewsDetail.slots.tsx
+++ b/src/documentation/examples/NewsDetail.slots.tsx
@@ -1,0 +1,113 @@
+import { ImageProps, SocialElement } from "@/types/fsxa-ui";
+import { Button, NewsDetail } from "fsxa-ui";
+import Vue from "vue";
+import Component from "vue-class-component";
+
+const image: ImageProps = {
+  resolutions: {
+    ORIGINAL: {
+      url:
+        "https://images.pexels.com/photos/2564028/pexels-photo-2564028.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=500",
+      width: 500,
+      height: 1,
+    },
+    LARGE: {
+      url:
+        "https://images.pexels.com/photos/911758/pexels-photo-911758.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1000",
+      width: 1000,
+      height: 1,
+    },
+  },
+  src:
+    "https://images.pexels.com/photos/911758/pexels-photo-911758.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=750&w=1000",
+};
+@Component
+export default class App extends Vue {
+  render() {
+    return (
+      <div>
+        <NewsDetail
+          headline="Futuring Human Mobility: Preparing the future for human mobility"
+          teaser="Berlin has „a special intensity“ says architect David Chipperfield at the opening of the exhibition „Futuring Human Mobility“ at the Bötzow site."
+          image={image}
+          date={new Date(2020, 0, 18).toLocaleDateString()}
+          author="Max Mustermann"
+          social={{
+            handleSocialClick: (socialElement: SocialElement) =>
+              alert(
+                `Title: ${socialElement.title} with id: ${socialElement.id}`,
+              ),
+            title: "Social Media",
+            items: [
+              {
+                title: "Facebook",
+                id: 1,
+                options: {
+                  icon: "fab fa-facebook-f",
+                },
+              },
+              {
+                title: "Twitter",
+                id: 2,
+                options: {
+                  icon: "fab fa-twitter",
+                },
+              },
+              {
+                title: "Instagram",
+                id: 3,
+                options: {
+                  icon: "fab fa-instagram",
+                },
+              },
+            ],
+          }}
+          scopedSlots={{
+            social: socialElement => {
+              return (
+                <div class="ui-mx-auto lg:ui-mx-px ui-text-center lg:ui-text-left">
+                  {socialElement.title ? (
+                    <h6 class="ui-font-extrabold ui-text-2xl">
+                      {socialElement.title}
+                    </h6>
+                  ) : null}
+                  {socialElement.items && socialElement.items.length > 0 ? (
+                    <div class="ui-space-x-2">
+                      {socialElement.items.map(element => (
+                        <Button
+                          handleClick={() => {
+                            if (socialElement.handleSocialClick)
+                              socialElement.handleSocialClick(element);
+                          }}
+                          variant="tag"
+                        >
+                          <i class={`${element.options.icon} fa-lg`}></i>
+                        </Button>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              );
+            },
+          }}
+        >
+          <div>
+            <p>
+              Otto Bock was founded 100 years ago in Berlin and today employs
+              7000 people. The company’s goal is to give people back their
+              complete mobility. According to Prof. Näder, however, the
+              anniversary is not meant to be the usual review of what has been
+              achieved, but rather to look into the future and to show visions
+              for human mobility. Especially with regard to artificial
+              intelligence. The result is a major work entitled „Futuring Human
+              Mobility“ and a matching exhibition. This can be seen until March
+              and is intended to attract more people to the Bötzow site. Due to
+              extensive restoration work, these have recently become rather
+              quiet.
+            </p>
+          </div>
+        </NewsDetail>
+      </div>
+    );
+  }
+}

--- a/src/documentation/examples/NewsDetail.tsx
+++ b/src/documentation/examples/NewsDetail.tsx
@@ -1,7 +1,7 @@
+import { SocialElement } from "@/types/fsxa-ui";
+import { NewsDetail, Quote } from "fsxa-ui";
 import Vue from "vue";
 import Component from "vue-class-component";
-
-import { NewsDetail, Quote } from "fsxa-ui";
 
 const tags = [{ label: "Mobility" }, { label: "Technology" }];
 const image = {
@@ -17,13 +17,31 @@ export default class App extends Vue {
           headline="Futuring Human Mobility: Preparing the future for human mobility"
           teaser="Berlin has „a special intensity“ says architect David Chipperfield at the opening of the exhibition „Futuring Human Mobility“ at the Bötzow site."
           image={image}
-          date={"2020-5-2"}
+          date={new Date(2020, 0, 18).toLocaleDateString()}
           author="Max Mustermann"
           tags={tags}
           handleTagClick={tag => console.log("clicked: " + tag.label)}
           handleReturnClick={() => console.log("return")}
-          socialText="Social Contact"
           returnText="Return"
+          social={{
+            handleSocialClick: (socialItem: SocialElement) =>
+              alert(socialItem.title),
+            title: "Social Media",
+            items: [
+              {
+                title: "Facebook",
+                id: 1,
+              },
+              {
+                title: "Twitter",
+                id: 2,
+              },
+              {
+                title: "Instagram",
+                id: 3,
+              },
+            ],
+          }}
         >
           <div>
             <p>

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -1,5 +1,5 @@
-import { Component } from "vue-tsx-support";
 import { VNode } from "vue";
+import { Component } from "vue-tsx-support";
 
 export type RenderedType =
   | JSX.Element
@@ -144,6 +144,10 @@ export interface ImageRef {
       height: number;
     }
   >;
+
+  /**
+   * Specfiy which size should be used with which viewport
+   */
   sizes?: string;
 }
 export interface ImageProps extends Omit<ImageRef, "type"> {
@@ -380,6 +384,40 @@ export interface Tag {
    * Label of the tag
    */
   label: string;
+  /**
+   * Id of the tag so that i can be identified
+   */
+  id?: number | string;
+}
+
+export interface SocialArea {
+  /**
+   * Title of the social area
+   */
+  title?: string;
+  /**
+   * social elements which should be displayed in the social area
+   */
+  items?: SocialElement[];
+  /**
+   * Callback for when a social element is clicked.
+   */
+  handleSocialClick?: (socialElement: SocialElement) => void;
+}
+
+export interface SocialElement {
+  /**
+   * Title of the social element which is displayed when no custom slot is used
+   */
+  title?: string;
+  /**
+   * Id of the social element so that i can be identified
+   */
+  id?: number | string;
+  /**
+   * Additional informations for one social element
+   */
+  options?: any;
 }
 
 export interface NewsDetailProps {
@@ -394,9 +432,7 @@ export interface NewsDetailProps {
   /**
    * Object with a src attribute for the image.
    */
-  image: {
-    src: string;
-  };
+  image: ImageProps;
   /**
    * Date when the article is written. String should be ISO 8601 conform.
    */
@@ -425,12 +461,24 @@ export interface NewsDetailProps {
    */
   returnText?: string;
   /**
-   * Text above the social links.
+   * Area for social elements displayed under the article
    */
-  socialText?: string;
+  social?: SocialArea;
 }
 
-export class NewsDetail extends Component<NewsDetailProps> {}
+export interface NewsDetailSlots {
+  /**
+   * You can override the social area rendering of this component by specifying the slot social
+   * It will receive the social-area-data as parameter
+   */
+  social: SocialArea;
+}
+
+export class NewsDetail extends Component<
+  NewsDetailProps,
+  {},
+  NewsDetailSlots
+> {}
 
 export interface QuoteProps {
   /**


### PR DESCRIPTION
To provide a better user experience some properties has been changed. The image now uses the actual
image props, the date is not a date anymore but a string which is directy displayed and there is a
new way to display the social icons with a slot which can be used

BREAKING CHANGE: The property date has been changed from Date to string. The property socialText
does not exist anymore and is transformed an object.