### PR TITLE
TNG-809-fix-image

### DIFF
--- a/src/components/Image/__tests__/Image.spec.ts
+++ b/src/components/Image/__tests__/Image.spec.ts
@@ -47,7 +47,7 @@ describe("components/Image", () => {
       const veilDiv = getByTestId("veil");
       expect(veilDiv.classList.contains("ui-opacity-75")).toBe(true);
     });
-    it("should throw an error if the darken prop has not one of the preset values", () => {
+    it("should throw an error if the darken prop does not have one of the preset values", () => {
       //it should suffice to use shallowMount here, as the validation happens in the mount hook but for some reason shallow mount
       //didn't accept the options object
       expect(() =>

--- a/src/components/Image/__tests__/Image.spec.ts
+++ b/src/components/Image/__tests__/Image.spec.ts
@@ -4,29 +4,6 @@ import Image from "./../";
 const testImage = "[image location]";
 
 describe("components/Image", () => {
-  it("should have no border class and no 'veil' div when border and opacity properties are not set", () => {
-    const { getByTestId } = render(Image, {
-      props: {
-        src: testImage,
-      },
-    });
-    const image = getByTestId("imageDiv");
-    expect(image.classList.contains("border")).toBe(false);
-    expect(() => getByTestId("veil")).toThrow();
-  });
-
-  // ToDo: relying too much on internal structure, remove test?
-  it("should be followed by 'veil' div with class 'opacity-75', if initialized with the respective property", () => {
-    const { getByTestId } = render(Image, {
-      props: {
-        src: testImage,
-        opacity: 75,
-      },
-    });
-    const veilDiv = getByTestId("veil");
-    expect(veilDiv.classList.contains("ui-opacity-75")).toBe(true);
-  });
-
   it("should have an img tag with class 'zoom' when the zoom property is set", () => {
     const { getByTestId } = render(Image, {
       props: {
@@ -56,5 +33,31 @@ describe("components/Image", () => {
       fail("img tag not found");
     }
     expect(imgTag.getAttribute("src")).toEqual("");
+  });
+
+  describe("given a darken prop", () => {
+    // ToDo: relying too much on internal structure, remove test?
+    it("should be followed by 'veil' div with class 'opacity-75'", () => {
+      const { getByTestId } = render(Image, {
+        props: {
+          src: testImage,
+          darken: 75,
+        },
+      });
+      const veilDiv = getByTestId("veil");
+      expect(veilDiv.classList.contains("ui-opacity-75")).toBe(true);
+    });
+    it("should throw an error if the darken prop has not one of the preset values", () => {
+      //it should suffice to use shallowMount here, as the validation happens in the mount hook but for some reason shallow mount
+      //didn't accept the options object
+      expect(() =>
+        render(Image, {
+          props: {
+            src: testImage,
+            darken: 1,
+          },
+        }),
+      ).toThrow();
+    });
   });
 });

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -1,6 +1,7 @@
 import BaseComponent from "../BaseComponent";
 import { Component, Prop } from "vue-property-decorator";
 import throttle from "lodash.throttle";
+import { checkPassedValue } from "../utils/PropertyChecker/PropertyChecker";
 
 import "./style.css";
 import { ImageProps } from "@/types/fsxa-ui";
@@ -47,18 +48,8 @@ class Image extends BaseComponent<ImageProps> {
     this.throttledLazyLoadHandler = throttle(this.lazyLoadImage, 150);
   }
 
-  validateOpacity(opacity: string | number | undefined) {
-    return validDarkenValues.includes(Number(opacity));
-  }
-
   mounted() {
-    if (this.darken && !this.validateOpacity(this.darken)) {
-      throw new Error(
-        `Darken value is ${
-          this.darken
-        }. It should be one of ${validDarkenValues.join(", ")}`,
-      );
-    }
+    checkPassedValue(this.$el, validDarkenValues, this.darken, "darken");
     if (this.lazy) {
       // initially call handler to ensure that already visible images will be loaded too
       this.lazyLoadImage();

--- a/src/components/Image/index.tsx
+++ b/src/components/Image/index.tsx
@@ -14,6 +14,8 @@ const opacityClasses = {
   80: "ui-opacity-80",
 };
 
+const validDarkenValues = [0, 25, 40, 50, 75, 80];
+
 const isInViewport = (element: Element, preloadMultiplier = 1.1) => {
   const bounding = element.getBoundingClientRect();
   return (
@@ -34,7 +36,7 @@ class Image extends BaseComponent<ImageProps> {
   @Prop() sizes: ImageProps["sizes"];
   @Prop({ required: false }) lazy!: ImageProps["lazy"];
   @Prop({ required: false }) zoom!: ImageProps["zoom"];
-  @Prop({ required: false }) opacity!: ImageProps["opacity"];
+  @Prop({ required: false }) darken!: ImageProps["darken"];
   @Prop({ required: false }) previewId!: ImageProps["previewId"];
 
   throttledLazyLoadHandler: any;
@@ -45,7 +47,18 @@ class Image extends BaseComponent<ImageProps> {
     this.throttledLazyLoadHandler = throttle(this.lazyLoadImage, 150);
   }
 
+  validateOpacity(opacity: string | number | undefined) {
+    return validDarkenValues.includes(Number(opacity));
+  }
+
   mounted() {
+    if (this.darken && !this.validateOpacity(this.darken)) {
+      throw new Error(
+        `Darken value is ${
+          this.darken
+        }. It should be one of ${validDarkenValues.join(", ")}`,
+      );
+    }
     if (this.lazy) {
       // initially call handler to ensure that already visible images will be loaded too
       this.lazyLoadImage();
@@ -108,10 +121,10 @@ class Image extends BaseComponent<ImageProps> {
               this.zoom ? "zoom" : ""
             } ui-w-full ui-h-full ui-object-cover ui-object-center`}
           />
-          {this.opacity && (
+          {this.darken && (
             <div
               class={`ui-absolute ui-top-0 ui-left-0 ui-w-full ui-h-full ui-pointer-events-none ui-bg-black ${
-                opacityClasses[this.opacity]
+                opacityClasses[this.darken]
               }`}
               data-testid="veil"
             />

--- a/src/components/NewsTeaserItem/index.tsx
+++ b/src/components/NewsTeaserItem/index.tsx
@@ -29,7 +29,7 @@ class NewsTeaserItem extends BaseComponent<NewsTeaserItemProps> {
             class="ui-absolute ui-left-0 ui-top-0 ui-w-full"
             src={this.image.src}
             previewId={this.image.previewId}
-            opacity="40"
+            darken={40}
           />
         )}
         <div class="NewsTeaserItem--InfoBox md:ui-ml-0 md:ui-mt-10 md:ui--mr-10">

--- a/src/components/Sections/HeaderSection/index.tsx
+++ b/src/components/Sections/HeaderSection/index.tsx
@@ -35,7 +35,7 @@ class HeaderSection extends BaseComponent<
                 data-preview-id={this.backgroundImage?.previewId}
                 data-testid="HeaderSection--BackgroundImage"
                 class="ui-absolute ui-top-0 ui-left-0 ui-w-full ui-h-full"
-                opacity="80"
+                darken={80}
               />
             )}
 

--- a/src/components/Sections/InterestingFactsSection/index.tsx
+++ b/src/components/Sections/InterestingFactsSection/index.tsx
@@ -35,7 +35,7 @@ class InterestingFactsSection extends BaseComponent<
         {this.backgroundImage && (
           <Image
             class="InterestingFactsSection--BackgroundImage"
-            opacity="80"
+            darken={75}
             data-preview-id={this.backgroundImage.previewId}
             src={this.backgroundImage.src}
             resolutions={this.backgroundImage.resolutions}

--- a/src/components/Sections/ListSection/__tests__/ListSection.spec.tsx
+++ b/src/components/Sections/ListSection/__tests__/ListSection.spec.tsx
@@ -156,7 +156,6 @@ describe("components/ListSection", () => {
       ...testSetup,
       scopedSlots: scopedSlotsWithHeadline,
     });
-    console.log(getByText("Test headline"));
     expect(getByText("Test headline").tagName).not.toBe("H1");
     expect(getByTestId("rendered-headline")).toBeTruthy();
   });

--- a/src/components/Sections/ProductDetailSection/__tests__/ProductDetailSection.spec.tsx
+++ b/src/components/Sections/ProductDetailSection/__tests__/ProductDetailSection.spec.tsx
@@ -42,12 +42,6 @@ const propertyList: ProductProperty[] = [
   },
 ];
 
-const foldableContentList: Record<string, string> = {
-  Delivery: `delivery`,
-  "Installation instructions": "instructions",
-  Compatibility: `compatibility`,
-};
-
 const componentProperties = {
   description,
   headline,
@@ -59,7 +53,6 @@ const componentProperties = {
     { src: src2, dimensions: { width: 5, height: 2 } },
   ],
   propertyList,
-  foldableContentList,
 };
 
 const expectToExist = (container: HTMLElement, elements: string[]) => {
@@ -104,7 +97,6 @@ describe("components/sections/ProductDetailSection", () => {
     expectToExistNTimes(container, [
       { key: "ProductDetail--Property--Headline", expectedInstanceCount: 2 },
       { key: "ProductDetail--Property--List", expectedInstanceCount: 2 },
-      { key: "ProductDetail--Accordion", expectedInstanceCount: 3 },
     ]);
 
     expect(getByTestId(`ProductDetail--Headline`)?.textContent).toEqual(
@@ -132,17 +124,6 @@ describe("components/sections/ProductDetailSection", () => {
     expect(propertyNodes[0].textContent).toEqual("Door Locks");
     expect(propertyNodes[1].textContent).toEqual(
       "Google HomeAmazon AlexaBosch Smart Home",
-    );
-
-    const accordionNodes = container.querySelectorAll(
-      `.ProductDetail--Accordion .Accordion--Text-Box`,
-    );
-    expect(accordionNodes[0].textContent).toEqual(foldableContentList.Delivery);
-    expect(accordionNodes[1].textContent).toEqual(
-      foldableContentList["Installation instructions"],
-    );
-    expect(accordionNodes[2].textContent).toEqual(
-      foldableContentList.Compatibility,
     );
   });
 

--- a/src/components/utils/PropertyChecker/PropertyChecker.ts
+++ b/src/components/utils/PropertyChecker/PropertyChecker.ts
@@ -3,12 +3,12 @@
  * @param vueElement Vue Element: In this context it will be: this.$el
  * @param possibleOptions: An array of possible options.
  * @param actualValue: A value to check for inclusion in the possibleOptions array.
- * @param valueName: Name for better error message. Describes which value was set incorrectly
+ * @param valueName: Name for better error message. Describes which value was set incorrectly.
  */
 const checkPassedValue = (
   vueElement: Element,
-  possibleOptions: string[],
-  actualValue: string | undefined,
+  possibleOptions: any[],
+  actualValue: any | undefined,
   valueName?: string,
 ) => {
   if (!actualValue) return;
@@ -17,7 +17,7 @@ const checkPassedValue = (
     throw new Error(
       `The ${
         valueName ? valueName : "element"
-      } '${actualValue}' is not available.`,
+      } value '${actualValue}' is not available in '${possibleOptions}'.`,
     );
   }
 };

--- a/src/components/utils/PropertyChecker/__tests__/PropertyChecker.spec.ts
+++ b/src/components/utils/PropertyChecker/__tests__/PropertyChecker.spec.ts
@@ -31,7 +31,7 @@ describe("utils/PropertyChecker/checkPassedValue", () => {
   });
 
   it("should throw error with correct message without valueName", () => {
-    const expectedString = `The element '${testingValue}' is not available.`;
+    const expectedString = `The element value '${testingValue}' is not available in '${testingArray}'.`;
     expect(() =>
       checkPassedValue(mockedVueElement, testingArray, testingValue),
     ).toThrowError(expectedString);
@@ -40,7 +40,7 @@ describe("utils/PropertyChecker/checkPassedValue", () => {
 
   it("should throw error with correct message with valueName", () => {
     const testingName = "TestName";
-    const expectedString = `The ${testingName} '${testingValue}' is not available.`;
+    const expectedString = `The ${testingName} value '${testingValue}' is not available in '${testingArray}'.`;
 
     expect(() =>
       checkPassedValue(

--- a/src/documentation/docs/components/Image.mdx
+++ b/src/documentation/docs/components/Image.mdx
@@ -18,8 +18,8 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
   <PropsTableRow value="alt" type="String">
     An alternative title that describes the image.
   </PropsTableRow>
-  <PropsTableRow value="opacity" type="String" default="0">
-    Specifies the opacity of a black overlay. Possible values are 
+  <PropsTableRow value="darken" type="String" default="0">
+    Specifies the opacity of a black overlay to darken the image. Possible values are 
     <span class="code">0</span>
     <span class="code">25</span>
     <span class="code">40</span>
@@ -34,8 +34,20 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
   <PropsTableRow value="lazy" type="Boolean" default="false">
     Specifies whether the image should be lazy loaded or not.
   </PropsTableRow>
-  <PropsTableRow value="dimensions" type="Object">
-    Specifies the width and height of the image. Takes An object with a <span class="code">width</span> and a <span class="code">height</span> number property.
+  <PropsTableRow value="resolutions" type="Array">
+    An array of properties required to build a source set of images. Each item requires the following properties.
+    <span class="code">url</span>
+    <span class="code">width</span>
+    <span class="code">height</span>
+  </PropsTableRow>
+  <PropsTableRow value="sizes" type="string">
+    <p>A string with the following syntax <span class="code">"([css-media-query]: [number]px) [number]px,(...),(...)"</span>.
+    Meaning if the media matches the query, take the image with the following width.</p>
+    <p>Example: <span class="code">"(min-width: 720px) 100px</span></p>
+    See also -> <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#attr-sizes">MDN docs</a>
+  </PropsTableRow>
+  <PropsTableRow value="previewId" type="string">
+    The FirstSpirit previewId.
   </PropsTableRow>
 </PropsTable>
 

--- a/src/documentation/docs/components/NewsDetail.mdx
+++ b/src/documentation/docs/components/NewsDetail.mdx
@@ -31,7 +31,7 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
     <li><span class="code">lazy</span>boolean - Specify if the image should be loaded only if it is visible in the viewport</li>
     <li><span class="code">border</span>boolean - Specify if the shift / border should be applied</li>
     <li><span class="code">zoom</span>boolean - Specify if the zoom-effect should be applied</li>
-    <li><span class="code">opacity</span>string - Specify if a black overlay with specified opacity should be applied on top. Possible values are "0" | "25" | "40" | "50" | "75" | "80"</li>
+    <li><span class="code">darken</span>string - Specify if a black overlay with specified opacity should be applied on top. Possible values are "0" | "25" | "40" | "50" | "75" | "80"</li>
     </ul>
   </PropsTableRow>
   <PropsTableRow value="teaser" type="String">

--- a/src/documentation/examples/Image.tsx
+++ b/src/documentation/examples/Image.tsx
@@ -10,7 +10,7 @@ const imageSrc =
 export default class App extends Vue {
   render() {
     return (
-      <div>
+      <div class="ui-w-full lg:ui-w-2/3 lg:ui-mx-auto">
         <Image src={imageSrc} darken="0" zoom={true} />
         <Image src={imageSrc} darken="40" zoom={false} />
         <Image src={imageSrc} darken="80" zoom={true} />

--- a/src/documentation/examples/Image.tsx
+++ b/src/documentation/examples/Image.tsx
@@ -11,9 +11,9 @@ export default class App extends Vue {
   render() {
     return (
       <div>
-        <Image src={imageSrc} opacity="0" zoom={true} />
-        <Image src={imageSrc} opacity="40" zoom={false} />
-        <Image src={imageSrc} opacity="80" zoom={true} />
+        <Image src={imageSrc} darken="0" zoom={true} />
+        <Image src={imageSrc} darken="40" zoom={false} />
+        <Image src={imageSrc} darken="80" zoom={true} />
       </div>
     );
   }

--- a/src/documentation/examples/Sections/FullWidthSliderSection.Images.slots.tsx
+++ b/src/documentation/examples/Sections/FullWidthSliderSection.Images.slots.tsx
@@ -31,7 +31,7 @@ class App extends Vue {
               <Image
                 src={slideMedia.src}
                 class="HeaderSection--BackgroundImage"
-                opacity="0"
+                darken={0}
               />
             ),
             arrowButtonContent: props => (

--- a/src/documentation/examples/Sections/HeaderSection.slots.tsx
+++ b/src/documentation/examples/Sections/HeaderSection.slots.tsx
@@ -32,7 +32,7 @@ export default class App extends Vue {
               <Image
                 src={src}
                 class="ui-absolute ui-top-0 ui-left-0 ui-w-full ui-h-full"
-                opacity="40"
+                darken={40}
               />
             ),
             breadcrumbs: () => <div>my own breadcrumbs alternative</div>,

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -151,7 +151,7 @@ export interface ImageRef {
   >;
 
   /**
-   * Specifiy which size should be used with which viewport
+   * Specify which size should be used with which viewport
    */
   sizes?: string;
 }
@@ -178,9 +178,9 @@ export interface ImageProps extends Omit<ImageRef, "type"> {
   /**
    * Should a black overlay with specified opacity be displayed on top?
    *
-   * Possible values are: **25**, **50**, **75**, **80**
+   * Possible values are: **0**, **25**, **40**, **50**, **75**, and **80**
    */
-  darken?: "0" | "25" | "40" | "50" | "75" | "80";
+  darken?: 0 | 25 | 40 | 50 | 75 | 80;
 }
 export class Image extends Component<ImageProps> {}
 

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -151,7 +151,7 @@ export interface ImageRef {
   >;
 
   /**
-   * Specfiy which size should be used with which viewport
+   * Specifiy which size should be used with which viewport
    */
   sizes?: string;
 }
@@ -180,7 +180,7 @@ export interface ImageProps extends Omit<ImageRef, "type"> {
    *
    * Possible values are: **25**, **50**, **75**, **80**
    */
-  opacity?: "0" | "25" | "40" | "50" | "75" | "80";
+  darken?: "0" | "25" | "40" | "50" | "75" | "80";
 }
 export class Image extends Component<ImageProps> {}
 


### PR DESCRIPTION
fix(image component): using an illegal value for "darken" (fka "opacity") now throws an error

The opacity prop is now named "darken" and a validation method was added. It should throw an error
if an illegal value is used. And should accept strings and numbers (if the component is being used
in a javascript environment). If an error is thrown, it will still result in a black image. Also
updated the documentation.