### PR TITLE
googlemaps-default-language

### DIFF
--- a/src/components/Sections/GoogleMapsSection/index.tsx
+++ b/src/components/Sections/GoogleMapsSection/index.tsx
@@ -104,7 +104,7 @@ class GoogleMapsSection extends BaseComponent<
   @Prop({ required: true })
   startLocation!: GoogleMapsSectionProps["startLocation"];
 
-  @Prop({ default: navigator.language })
+  @Prop()
   language: GoogleMapsSectionProps["language"] | undefined;
   @Prop()
   buttonLabel: GoogleMapsSectionProps["buttonLabel"];


### PR DESCRIPTION
fix(googlemaps section): removed default value for language prop