### PR TITLE
fix(accordionsection): fixed accordionSection

### DIFF
--- a/src/components/Sections/AccordionSection/index.tsx
+++ b/src/components/Sections/AccordionSection/index.tsx
@@ -29,7 +29,11 @@ class AccordionSection extends BaseComponent<AccordionSectionProps> {
             open={index === this.selectedIndex}
             on-toggleCollapse={this.toggleCollapse.bind(this, index)}
           >
-            <p>{item.text}</p>
+            {typeof item.text === "string" ? (
+              <span>{item.text}</span>
+            ) : (
+              item.text
+            )}
           </Accordion>
         ))}
       </div>


### PR DESCRIPTION
There was a p-tag in the AccordionSection which led to errors in SSR. This was exchanged with a
span-element when there is only text or otherwise the full passed text with its tags.