### PR TITLE
docs: TNG-889 Add routes for the components that use Codesandbox

### DIFF
--- a/src/components/internal/Documentation/ComponentWrapper/index.tsx
+++ b/src/components/internal/Documentation/ComponentWrapper/index.tsx
@@ -1,5 +1,5 @@
 import BaseComponent from "@/components/BaseComponent";
-import { Component } from "vue-property-decorator";
+import { Component, Prop } from "vue-property-decorator";
 import "vue-tsx-support/enable-check";
 import ResponsiveButton from "../ResponsiveButton";
 import TableLegend from "@/components/internal/Documentation/TableLegend";
@@ -8,11 +8,19 @@ interface ComponentWrapperSlots {
   infoSlot: void;
   codeSlot: void;
 }
+interface ComponentWrapperProps {
+  url: string;
+}
 
 @Component({
   name: "ComponentWrapper",
 })
-class ComponentWrapper extends BaseComponent<{}, {}, ComponentWrapperSlots> {
+class ComponentWrapper extends BaseComponent<
+  ComponentWrapperProps,
+  {},
+  ComponentWrapperSlots
+> {
+  @Prop() url: ComponentWrapperProps["url"];
   state = 2;
   render() {
     return (
@@ -37,6 +45,11 @@ class ComponentWrapper extends BaseComponent<{}, {}, ComponentWrapperSlots> {
             >
               <i class="fas fa-code" /> Example
             </ResponsiveButton>
+            <a href={this.url} target="_blank">
+              <ResponsiveButton class={`ui-rounded`} title="codesandbox">
+                <i class="fas fa-code" /> Code Sandbox
+              </ResponsiveButton>
+            </a>
           </div>
         </div>
         {this.state === 1 ? (

--- a/src/components/internal/Documentation/ComponentWrapper/index.tsx
+++ b/src/components/internal/Documentation/ComponentWrapper/index.tsx
@@ -20,7 +20,7 @@ class ComponentWrapper extends BaseComponent<
   {},
   ComponentWrapperSlots
 > {
-  @Prop() url: ComponentWrapperProps["url"];
+  @Prop() url!: ComponentWrapperProps["url"];
   state = 2;
   render() {
     return (

--- a/src/components/internal/Documentation/ResponsiveButton/index.tsx
+++ b/src/components/internal/Documentation/ResponsiveButton/index.tsx
@@ -3,7 +3,7 @@ import { Component, Prop } from "vue-property-decorator";
 import BaseComponent from "@/components/BaseComponent";
 
 interface ResponsiveButtonProps {
-  handleOnClick: () => void;
+  handleOnClick?: () => void;
   pressed?: boolean;
   dark?: boolean;
   title?: string;
@@ -13,7 +13,7 @@ interface ResponsiveButtonProps {
   name: "ResponsiveButton",
 })
 class ResponsiveButton extends BaseComponent<ResponsiveButtonProps> {
-  @Prop({ required: true })
+  @Prop({ required: false })
   handleOnClick!: ResponsiveButtonProps["handleOnClick"];
   @Prop({ default: false }) pressed!: ResponsiveButtonProps["pressed"];
   @Prop({ default: false }) dark!: ResponsiveButtonProps["dark"];

--- a/src/documentation/docs/Sections/AccordionSection.mdx
+++ b/src/documentation/docs/Sections/AccordionSection.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
   component={["Sections", "AccordionSection"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/AccordionSection.vue&initialpath=components/accordionSection" scopedSlots={{
   infoSlot: () =>
 <PropsTable>
   <PropsTableRow value="items" type="array of items" required>

--- a/src/documentation/docs/Sections/FullWidthSliderSection.mdx
+++ b/src/documentation/docs/Sections/FullWidthSliderSection.mdx
@@ -11,7 +11,7 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
   component={["Sections", "FullWidthSliderSection"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/FullWidthSliderSection.vue&initialpath=components/fullWidthSliderSection" scopedSlots={{
   infoSlot: () => <div>
 <PropsTable>
   <PropsTableRow value="slides" type="FullWidthSliderSectionSlide<MediaType>[]" required>   

--- a/src/documentation/docs/Sections/GoogleMapsSection.mdx
+++ b/src/documentation/docs/Sections/GoogleMapsSection.mdx
@@ -12,7 +12,7 @@ component={["Sections", "GoogleMapsSection"]}
 subtitle = "This section displays a Google Maps map optionally containing a set of locations to display as markers. The surrounding HTML element needs a height or the map won't be rendered."
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/GoogleMapsSection.vue&initialpath=components/googleMapsSection" scopedSlots={{
   infoSlot: () => <div>
 <PropsTable>
   <PropsTableRow value="apikey" type="string" required>

--- a/src/documentation/docs/Sections/HeaderSection.mdx
+++ b/src/documentation/docs/Sections/HeaderSection.mdx
@@ -13,7 +13,7 @@ import { Headline } from "@/components";
 component={["Sections", "HeaderSection"]}
 />
 
-<ComponentWrapper  scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/HeaderSection.vue&initialpath=components/headerSection"  scopedSlots={{
   codeSlot: () => <div><Headline as="h3" size="md" weight="light">
           Example
         </Headline><ExampleLoader example="Sections/HeaderSection.tsx" /><Headline as="h3" size="md" weight="light">

--- a/src/documentation/docs/Sections/InterestingFactsSection.mdx
+++ b/src/documentation/docs/Sections/InterestingFactsSection.mdx
@@ -11,7 +11,7 @@ import ComponentWrapper from "@/components/internal/Documentation/ComponentWrapp
   component={["Sections", "InterestingFactsSection"]}
 />
 
-<ComponentWrapper  scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/InterestingFactsSection.vue&initialpath=components/interestingFactsSection" scopedSlots={{
 infoSlot: () => <div>
 <PropsTable>
   <PropsTableRow value="headline" type="String" required>

--- a/src/documentation/docs/Sections/ListSection.mdx
+++ b/src/documentation/docs/Sections/ListSection.mdx
@@ -11,7 +11,7 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
   component={["Sections", "ListSection"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/ListSection.vue&initialpath=components/listSection" scopedSlots={{
   infoSlot: () => <div>
 <PropsTable>
   <PropsTableRow value="items" type="Item[]" required>

--- a/src/documentation/docs/Sections/ProductDetailSection.mdx
+++ b/src/documentation/docs/Sections/ProductDetailSection.mdx
@@ -11,7 +11,7 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
   component={["Sections", "ProductDetailSection"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/ProductDetailSection.vue&initialpath=components/productDetailSection" scopedSlots={{
   infoSlot: () => <div>
 <PropsTable>
   <PropsTableRow value="description" type="string" required>

--- a/src/documentation/docs/Sections/TeaserSection.mdx
+++ b/src/documentation/docs/Sections/TeaserSection.mdx
@@ -10,7 +10,7 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
   component={["Sections", "TeaserSection"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/TeaserSection.vue&initialpath=components/teaserSection" scopedSlots={{
   infoSlot: () => <div>
 <PropsTable>
       <PropsTableRow value="headline" type="string" required>

--- a/src/documentation/docs/components/Accordion.mdx
+++ b/src/documentation/docs/components/Accordion.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
   component={["Components", "Accordion"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Accordion.vue&initialpath=components/accordion" scopedSlots={{
   infoSlot: () => 
 <PropsTable>
   <PropsTableRow value="title" type="string" required>

--- a/src/documentation/docs/components/Button.mdx
+++ b/src/documentation/docs/components/Button.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
   component={["Components", "Button"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Button.vue&initialpath=components/button" scopedSlots={{
   infoSlot: () => 
 <PropsTable>
   <PropsTableRow value="handleClick" type="function">

--- a/src/documentation/docs/components/Container.mdx
+++ b/src/documentation/docs/components/Container.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
     component={["Components", "Container"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Container.vue&initialpath=components/container" scopedSlots={{
   infoSlot: () => 
 <PropsTable>
   <PropsTableRow value="fluid" type="Boolean" default="false">

--- a/src/documentation/docs/components/Counter.mdx
+++ b/src/documentation/docs/components/Counter.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
     component={["Components", "Counter"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Counter.vue&initialpath=components/counter" scopedSlots={{
   infoSlot: () => 
 <PropsTable>
   <PropsTableRow value="label" type="String" required>

--- a/src/documentation/docs/components/Dropdown.mdx
+++ b/src/documentation/docs/components/Dropdown.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
     component={["Components", "Dropdown"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Dropdown.vue&initialpath=components/dropdown" scopedSlots={{
   infoSlot: () => 
 <PropsTable>
   <PropsTableRow value="handleChange" type="Function" required>

--- a/src/documentation/docs/components/Headline.mdx
+++ b/src/documentation/docs/components/Headline.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
   component={["Components", "Headline"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Headline.vue&initialpath=components/headline" scopedSlots={{
   infoSlot: () => 
 <PropsTable>
   <PropsTableRow value="as" type="String" default="h1">

--- a/src/documentation/docs/components/Image.mdx
+++ b/src/documentation/docs/components/Image.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
     component={["Components", "Image"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Image.vue&initialpath=components/image" scopedSlots={{
   infoSlot: () => 
 <PropsTable>
   <PropsTableRow value="src" type="String" required>

--- a/src/documentation/docs/components/ImageSlider.mdx
+++ b/src/documentation/docs/components/ImageSlider.mdx
@@ -11,7 +11,7 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
     component={["Components", "ImageSlider"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/ImageSlider.vue&initialpath=components/imageSlider" scopedSlots={{
   infoSlot: () => <div>
 <PropsTable>
   <PropsTableRow value="images" type="Image[]" required>

--- a/src/documentation/docs/components/LineSeparator.mdx
+++ b/src/documentation/docs/components/LineSeparator.mdx
@@ -11,7 +11,7 @@ import { Headline } from "@/components";
     component={["Components", "LineSeparator"]}
 />
 
-<ComponentWrapper  scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/LineSeparator.vue&initialpath=components/lineSeperator"  scopedSlots={{
   codeSlot: () => <div>
     <Headline as="h3" size="md" weight="light">
           Example

--- a/src/documentation/docs/components/Navigation.mdx
+++ b/src/documentation/docs/components/Navigation.mdx
@@ -11,7 +11,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
 
  If you want distinct mobile and desktop navigation, define both and control by media query when to display which.
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Navigation.vue&initialpath=components/navigation" scopedSlots={{
   infoSlot: () => 
 <PropsTable>
   <PropsTableRow value="items" type="Array" required>

--- a/src/documentation/docs/components/NewsDetail.mdx
+++ b/src/documentation/docs/components/NewsDetail.mdx
@@ -11,7 +11,7 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
   component={["Components", "NewsDetail"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/NewsDetail.vue&initialpath=components/newsDetails" scopedSlots={{
   infoSlot: () => <div>
 <PropsTable>
   <PropsTableRow value="headline" type="String" required>

--- a/src/documentation/docs/components/ProductListItem.mdx
+++ b/src/documentation/docs/components/ProductListItem.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
   component={["Components", "ProductListItem"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/ProductListItem.vue&initialpath=components/productListItem" scopedSlots={{
   infoSlot: () =>
 <PropsTable>
   <PropsTableRow value="handleClick" type="function" required>

--- a/src/documentation/docs/components/Quote.mdx
+++ b/src/documentation/docs/components/Quote.mdx
@@ -9,7 +9,7 @@ import PropsTableRow from "@/components/internal/Documentation/PropsTable/compon
   component={["Components", "Quote"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Quote.vue&initialpath=components/quote" scopedSlots={{
   infoSlot: () =>
 <PropsTable>
   <PropsTableRow value="side" type="string" default="left">

--- a/src/documentation/docs/components/Slider.mdx
+++ b/src/documentation/docs/components/Slider.mdx
@@ -11,7 +11,7 @@ import SlotsTableRow from "@/components/internal/Documentation/SlotsTable/compon
   component={["Components", "Slider"]}
 />
 
-<ComponentWrapper scopedSlots={{
+<ComponentWrapper url="https://codesandbox.io/s/crazy-lovelace-irmgs?file=/src/views/components/Slider.vue&initialpath=components/slider" scopedSlots={{
   infoSlot: () => <div>
 <PropsTable>
   <PropsTableRow value="slideCount" type="number" required>


### PR DESCRIPTION
We have linked the FSXA components to their respective Codesandbox sample components, so that you can now go from our FSXA UI to the interactive code samples and edit them to illustrate the component.